### PR TITLE
Update Hubot to ^13.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/xurizaemon/hubot-startup#readme",
   "dependencies": {
-    "hubot": "^11"
+    "hubot": "^13.0.1"
   },
   "devDependencies": {
     "standard": "^17.1.2"


### PR DESCRIPTION
Earlier Hubots depended on a vulnerable connect-multiparty.